### PR TITLE
Fixed the parameter type of the extract_entity_nodes function from Li…

### DIFF
--- a/src/hipporag/utils/misc_utils.py
+++ b/src/hipporag/utils/misc_utils.py
@@ -78,7 +78,7 @@ def reformat_openie_results(corpus_openie_results) -> (Dict[str, NerRawOutput], 
 
     return ner_output_dict, triple_output_dict
 
-def extract_entity_nodes(chunk_triples: List[Triple]) -> (List[str], List[List[str]]):
+def extract_entity_nodes(chunk_triples: List[List[Triple]]) -> (List[str], List[List[str]]):
     chunk_triple_entities = []  # a list of lists of unique entities from each chunk's triples
     for triples in chunk_triples:
         triple_entities = set()


### PR DESCRIPTION
## Annotation update
The type annotation of the previous input parameter does not match the logic of the function. the updated version is showed below
<img width="767" alt="image" src="https://github.com/user-attachments/assets/3e0dc91d-4aa1-44e8-bec1-a5609446c942" />
