### PR TITLE
Allowing selecting embedding model's dtype manually

### DIFF
--- a/src/hipporag/embedding_model/Contriever.py
+++ b/src/hipporag/embedding_model/Contriever.py
@@ -55,7 +55,7 @@ class ContrieverModel(BaseEmbeddingModel):
                 # "model_name_or_path": self.embedding_model_name2mode_name_or_path[self.embedding_model_name],
                 "pretrained_model_name_or_path": self.embedding_model_name,
                 "trust_remote_code": True,
-                # "torch_dtype": "auto",
+                "torch_dtype": self.global_config.embedding_model_dtype,
                 'device_map': "auto",  # added this line to use multiple GPUs
                 # **kwargs
             },

--- a/src/hipporag/embedding_model/GritLM.py
+++ b/src/hipporag/embedding_model/GritLM.py
@@ -49,7 +49,7 @@ class GritLMEmbeddingModel(BaseEmbeddingModel):
             "norm": self.global_config.embedding_return_as_normalized,
             "model_init_params": {
                 "model_name_or_path": self.embedding_model_name,
-                "torch_dtype": "auto",
+                "torch_dtype": self.global_config.embedding_model_dtype,
                 "device_map": "auto", # added this line to use multiple GPUs
                 # **kwargs
             },

--- a/src/hipporag/embedding_model/NVEmbedV2.py
+++ b/src/hipporag/embedding_model/NVEmbedV2.py
@@ -46,8 +46,8 @@ class NVEmbedV2EmbeddingModel(BaseEmbeddingModel):
                 # "model_name_or_path": self.embedding_model_name2mode_name_or_path[self.embedding_model_name],
                 "pretrained_model_name_or_path": self.embedding_model_name,
                 "trust_remote_code": True,
-                # "torch_dtype": "auto",
                 'device_map': "auto",  # added this line to use multiple GPUs
+                "torch_dtype": self.global_config.embedding_model_dtype,
                 # **kwargs
             },
             "encode_params": {

--- a/src/hipporag/utils/config_utils.py
+++ b/src/hipporag/utils/config_utils.py
@@ -134,7 +134,7 @@ class BaseConfig:
         metadata={"help": "Max sequence length for the embedding model."}
     )
     embedding_model_dtype: Literal["float16", "float32", "bfloat16", "auto"] = field(
-        default=None,
+        default="auto",
         metadata={"help": "Data type for local embedding model."}
     )
     

--- a/src/hipporag/utils/config_utils.py
+++ b/src/hipporag/utils/config_utils.py
@@ -133,6 +133,10 @@ class BaseConfig:
         default=2048,
         metadata={"help": "Max sequence length for the embedding model."}
     )
+    embedding_model_dtype: Literal["float16", "float32", "bfloat16", "auto"] = field(
+        default=None,
+        metadata={"help": "Data type for local embedding model."}
+    )
     
     
     


### PR DESCRIPTION
The original weights of the NV-Embed-v2 model are of the fp16 type. However, in the current code, since the `torch_dtype` parameter is not passed to `from_pretrained()`, it is loaded in the default fp32 format, which wastes much VRAM. So I want to add an `embedding_model_dtype` parameter to `BaseConfig` to allow specifying the data type and halve the GPU memory consumption.