### PR TITLE
Fixed prompt mismatch issues when vectorizing with OpenAI and fixed problems related to deletion.

### DIFF
--- a/src/hipporag/HippoRAG.py
+++ b/src/hipporag/HippoRAG.py
@@ -299,13 +299,13 @@ class HippoRAG:
         all_openie_info, chunk_keys_to_process = self.load_existing_openie([])
         triples_to_delete = []
 
-        all_openie_info_with_deletes = []
+        all_openie_info_without_deletes = []
 
         for openie_doc in all_openie_info:
             if openie_doc['idx'] in chunk_ids_to_delete:
                 triples_to_delete.append(openie_doc['extracted_triples'])
             else:
-                all_openie_info_with_deletes.append(openie_doc)
+                all_openie_info_without_deletes.append(openie_doc)
 
         triples_to_delete = flatten_facts(triples_to_delete)
 
@@ -351,7 +351,7 @@ class HippoRAG:
         logger.info(f"Deleting {len(triple_ids_to_delete)} Triples")
         logger.info(f"Deleting {len(filtered_ent_ids_to_delete)} Entities")
 
-        self.save_openie_results(all_openie_info_with_deletes)
+        self.save_openie_results(all_openie_info_without_deletes)
 
         self.entity_embedding_store.delete(filtered_ent_ids_to_delete)
         self.fact_embedding_store.delete(triple_ids_to_delete)

--- a/src/hipporag/HippoRAG.py
+++ b/src/hipporag/HippoRAG.py
@@ -749,7 +749,7 @@ class HippoRAG:
             Does not explicitly raise exceptions within the provided function logic.
         """
 
-        if "name" in self.graph.vs:
+        if "name" in self.graph.vs.attribute_names():
             current_graph_nodes = set(self.graph.vs["name"])
         else:
             current_graph_nodes = set()

--- a/src/hipporag/HippoRAG.py
+++ b/src/hipporag/HippoRAG.py
@@ -759,23 +759,23 @@ class HippoRAG:
         for chunk_key, triples in tqdm(zip(chunk_ids, chunk_triples)):
             entities_in_chunk = set()
 
-            if chunk_key not in current_graph_nodes:
-                for triple in triples:
-                    triple = tuple(triple)
+            for triple in triples:
+                triple = tuple(triple)
 
-                    node_key = compute_mdhash_id(content=triple[0], prefix=("entity-"))
-                    node_2_key = compute_mdhash_id(content=triple[2], prefix=("entity-"))
+                node_key = compute_mdhash_id(content=triple[0], prefix=("entity-"))
+                node_2_key = compute_mdhash_id(content=triple[2], prefix=("entity-"))
 
+                entities_in_chunk.add(node_key)
+                entities_in_chunk.add(node_2_key)
+
+                if chunk_key not in current_graph_nodes:
                     self.node_to_node_stats[(node_key, node_2_key)] = self.node_to_node_stats.get(
                         (node_key, node_2_key), 0.0) + 1
                     self.node_to_node_stats[(node_2_key, node_key)] = self.node_to_node_stats.get(
                         (node_2_key, node_key), 0.0) + 1
 
-                    entities_in_chunk.add(node_key)
-                    entities_in_chunk.add(node_2_key)
-
-                for node in entities_in_chunk:
-                    self.ent_node_to_chunk_ids[node] = self.ent_node_to_chunk_ids.get(node, set()).union(set([chunk_key]))
+            for node in entities_in_chunk:
+                self.ent_node_to_chunk_ids[node] = self.ent_node_to_chunk_ids.get(node, set()).union(set([chunk_key]))
 
     def add_passage_edges(self, chunk_ids: List[str], chunk_triple_entities: List[List[str]]):
         """

--- a/src/hipporag/HippoRAG.py
+++ b/src/hipporag/HippoRAG.py
@@ -321,6 +321,9 @@ class HippoRAG:
 
             if len(non_deleted_docs) == 0:
                 true_triples_to_delete.append(triple)
+                del self.proc_triples_to_docs[str(proc_triple)]
+            else:
+                self.proc_triples_to_docs[str(proc_triple)] = non_deleted_docs
 
         processed_true_triples_to_delete = [[text_processing(list(triple)) for triple in true_triples_to_delete]]
         entities_to_delete, _ = extract_entity_nodes(processed_true_triples_to_delete)
@@ -340,6 +343,9 @@ class HippoRAG:
 
             if len(non_deleted_docs) == 0:
                 filtered_ent_ids_to_delete.append(ent_node)
+                del self.ent_node_to_chunk_ids[ent_node]
+            else:
+                self.ent_node_to_chunk_ids[ent_node] = non_deleted_docs
 
         logger.info(f"Deleting {len(chunk_ids_to_delete)} Chunks")
         logger.info(f"Deleting {len(triple_ids_to_delete)} Triples")

--- a/src/hipporag/embedding_model/OpenAI.py
+++ b/src/hipporag/embedding_model/OpenAI.py
@@ -84,14 +84,16 @@ class OpenAIEmbeddingModel(BaseEmbeddingModel):
         params = deepcopy(self.embedding_config.encode_params)
         if kwargs: params.update(kwargs)
 
-        if "instruction" in kwargs:
-            if kwargs["instruction"] != '':
-                params["instruction"] = f"Instruct: {kwargs['instruction']}\nQuery: "
-            # del params["instruction"]
-
+        instruction = ""
+        if "instruction" in kwargs and kwargs["instruction"] != '':
+            instruction = f"Instruct: {kwargs['instruction']}\nQuery: "
+            logger.info(f"Using instruction: {instruction}")
         logger.debug(f"Calling {self.__class__.__name__} with:\n{params}")
 
         batch_size = params.pop("batch_size", 16)
+
+        if instruction:
+            texts = [instruction + text for text in texts]
 
         if len(texts) <= batch_size:
             results = self.encode(texts)


### PR DESCRIPTION
Hi ！
While reviewing other embedding examples, I noticed that they typically use `**params` —specifically by concatenating the prompt with the input texts before vectorization. However, I observed that OpenAI's embedding approach directly uses the raw texts without concatenation.
I wanted to check if this was an intentional design decision. If not, I’ve prepared a modification (included in this PR) that aligns with OpenAI’s approach. 

Thanks for maintaining this project—really appreciate the work you’ve done!