### PR TITLE
feat: add pluggable vector database backends (Qdrant, ChromaDB)

### DIFF
--- a/src/hipporag/HippoRAG.py
+++ b/src/hipporag/HippoRAG.py
@@ -19,10 +19,11 @@ import time
 
 from .llm import _get_llm_class, BaseLLM
 from .embedding_model import _get_embedding_model_class, BaseEmbeddingModel
-from .embedding_store import EmbeddingStore
+from .embedding_store import EmbeddingStore, get_embedding_store
 from .information_extraction import OpenIE
-from .information_extraction.openie_vllm_offline import VLLMOfflineOpenIE
-from .information_extraction.openie_transformers_offline import TransformersOfflineOpenIE
+# VLLMOfflineOpenIE and TransformersOfflineOpenIE are imported lazily inside
+# __init__ so that vllm (Linux-only) and heavy Transformers deps are never
+# loaded unless the user explicitly requests offline OpenIE mode.
 from .evaluation.retrieval_eval import RetrievalRecall
 from .evaluation.qa_eval import QAExactMatch, QAF1Score
 from .prompts.linking import get_query_instruction
@@ -127,8 +128,10 @@ class HippoRAG:
         if self.global_config.openie_mode == 'online':
             self.openie = OpenIE(llm_model=self.llm_model)
         elif self.global_config.openie_mode == 'offline':
+            from .information_extraction.openie_vllm_offline import VLLMOfflineOpenIE
             self.openie = VLLMOfflineOpenIE(self.global_config)
-        elif self.global_config.openie_mode ==  'Transformers-offline':
+        elif self.global_config.openie_mode == 'Transformers-offline':
+            from .information_extraction.openie_transformers_offline import TransformersOfflineOpenIE
             self.openie = TransformersOfflineOpenIE(self.global_config)
 
         self.graph = self.initialize_graph()
@@ -139,15 +142,27 @@ class HippoRAG:
             self.embedding_model: BaseEmbeddingModel = _get_embedding_model_class(
                 embedding_model_name=self.global_config.embedding_model_name)(global_config=self.global_config,
                                                                               embedding_model_name=self.global_config.embedding_model_name)
-        self.chunk_embedding_store = EmbeddingStore(self.embedding_model,
-                                                    os.path.join(self.working_dir, "chunk_embeddings"),
-                                                    self.global_config.embedding_batch_size, 'chunk')
-        self.entity_embedding_store = EmbeddingStore(self.embedding_model,
-                                                     os.path.join(self.working_dir, "entity_embeddings"),
-                                                     self.global_config.embedding_batch_size, 'entity')
-        self.fact_embedding_store = EmbeddingStore(self.embedding_model,
-                                                   os.path.join(self.working_dir, "fact_embeddings"),
-                                                   self.global_config.embedding_batch_size, 'fact')
+        self.chunk_embedding_store = get_embedding_store(
+            self.embedding_model,
+            os.path.join(self.working_dir, "chunk_embeddings"),
+            self.global_config.embedding_batch_size,
+            'chunk',
+            self.global_config,
+        )
+        self.entity_embedding_store = get_embedding_store(
+            self.embedding_model,
+            os.path.join(self.working_dir, "entity_embeddings"),
+            self.global_config.embedding_batch_size,
+            'entity',
+            self.global_config,
+        )
+        self.fact_embedding_store = get_embedding_store(
+            self.embedding_model,
+            os.path.join(self.working_dir, "fact_embeddings"),
+            self.global_config.embedding_batch_size,
+            'fact',
+            self.global_config,
+        )
 
         self.prompt_template_manager = PromptTemplateManager(role_mapping={"system": "system", "user": "user", "assistant": "assistant"})
 

--- a/src/hipporag/StandardRAG.py
+++ b/src/hipporag/StandardRAG.py
@@ -19,7 +19,7 @@ import time
 
 from .llm import _get_llm_class, BaseLLM
 from .embedding_model import _get_embedding_model_class, BaseEmbeddingModel
-from .embedding_store import EmbeddingStore
+from .embedding_store import EmbeddingStore, get_embedding_store
 from .information_extraction import OpenIE
 from .information_extraction.openie_vllm_offline import VLLMOfflineOpenIE
 from .evaluation.retrieval_eval import RetrievalRecall
@@ -91,12 +91,13 @@ class StandardRAG:
                 embedding_model_name=self.global_config.embedding_model_name)(global_config=self.global_config,
                                                                               embedding_model_name=self.global_config.embedding_model_name)
 
-        import ipdb;
-        ipdb.set_trace()
-
-        self.chunk_embedding_store = EmbeddingStore(self.embedding_model,
-                                                    os.path.join(self.working_dir, "chunk_embeddings"),
-                                                    self.global_config.embedding_batch_size, 'chunk')
+        self.chunk_embedding_store = get_embedding_store(
+            self.embedding_model,
+            os.path.join(self.working_dir, "chunk_embeddings"),
+            self.global_config.embedding_batch_size,
+            'chunk',
+            self.global_config,
+        )
 
         self.ready_to_retrieve = False
 

--- a/src/hipporag/embedding_model/base.py
+++ b/src/hipporag/embedding_model/base.py
@@ -221,29 +221,44 @@ class BaseEmbeddingModel:
 
 class EmbeddingCache:
     """A multiprocessing-safe global cache for storing embeddings."""
-    
-    _manager = multiprocessing.Manager()
-    _cache = _manager.dict()  # Shared dictionary for multiprocessing
-    _lock = threading.Lock()  # Thread-safe lock for concurrent access
+
+    _manager = None
+    _cache = None
+    _lock = threading.Lock()
+
+    @classmethod
+    def _ensure_initialized(cls):
+        # Lazy init so multiprocessing.Manager() is never called at import time.
+        # On Windows (spawn), calling Manager() at class-body level crashes because
+        # the spawned child re-imports the module before __main__ is ready.
+        if cls._manager is None:
+            with cls._lock:
+                if cls._manager is None:
+                    cls._manager = multiprocessing.Manager()
+                    cls._cache = cls._manager.dict()
 
     @classmethod
     def get(cls, content):
         """Retrieve the embedding if cached."""
+        cls._ensure_initialized()
         return cls._cache.get(content)
 
     @classmethod
     def set(cls, content, embedding):
         """Store an embedding in the cache."""
-        with cls._lock:  # Ensures thread safety
+        cls._ensure_initialized()
+        with cls._lock:
             cls._cache[content] = embedding
 
     @classmethod
     def contains(cls, content):
         """Check if the embedding exists in cache."""
+        cls._ensure_initialized()
         return content in cls._cache
 
     @classmethod
     def clear(cls):
         """Clear the entire cache."""
+        cls._ensure_initialized()
         with cls._lock:
             cls._cache.clear()

--- a/src/hipporag/embedding_store.py
+++ b/src/hipporag/embedding_store.py
@@ -1,33 +1,91 @@
 import numpy as np
-from tqdm import tqdm
 import os
+from abc import ABC, abstractmethod
+from hashlib import md5
 from typing import Union, Optional, List, Dict, Set, Any, Tuple, Literal
 import logging
 from copy import deepcopy
 import pandas as pd
 
-from .utils.misc_utils import compute_mdhash_id, NerRawOutput, TripleRawOutput
+
+def compute_mdhash_id(content: str, prefix: str = "") -> str:
+    """Return prefix + MD5 hex digest of content. Mirrors utils.misc_utils."""
+    return prefix + md5(content.encode()).hexdigest()
 
 logger = logging.getLogger(__name__)
 
-class EmbeddingStore:
-    def __init__(self, embedding_model, db_filename, batch_size, namespace):
-        """
-        Initializes the class with necessary configurations and sets up the working directory.
 
-        Parameters:
-        embedding_model: The model used for embeddings.
-        db_filename: The directory path where data will be stored or retrieved.
-        batch_size: The batch size used for processing.
-        namespace: A unique identifier for data segregation.
+class BaseEmbeddingStore(ABC):
+    """
+    Abstract base class for all embedding store backends.
 
-        Functionality:
-        - Assigns the provided parameters to instance variables.
-        - Checks if the directory specified by `db_filename` exists.
-          - If not, creates the directory and logs the operation.
-        - Constructs the filename for storing data in a parquet file format.
-        - Calls the method `_load_data()` to initialize the data loading process.
-        """
+    All backends must expose a ``text_to_hash_id`` dict-like attribute that
+    maps raw text → its hash ID, because HippoRAG.delete() accesses it directly.
+    """
+
+    namespace: str
+    embedding_model: Any
+    batch_size: int
+
+    # Must be kept in-sync by every subclass (populated on init, insert, delete)
+    text_to_hash_id: Dict[str, str]
+
+    # ------------------------------------------------------------------
+    # Concrete helper — same logic regardless of backend
+    # ------------------------------------------------------------------
+
+    def get_missing_string_hash_ids(self, texts: List[str]) -> Dict[str, Dict]:
+        """Return {hash_id: row} for texts not yet stored."""
+        existing = set(self.get_all_ids())
+        result = {}
+        for text in texts:
+            h = compute_mdhash_id(text, prefix=self.namespace + "-")
+            if h not in existing:
+                result[h] = {"hash_id": h, "content": text}
+        return result
+
+    def get_hash_id(self, text: str) -> str:
+        return self.text_to_hash_id[text]
+
+    # ------------------------------------------------------------------
+    # Abstract interface
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def insert_strings(self, texts: List[str]) -> None: ...
+
+    @abstractmethod
+    def delete(self, hash_ids) -> None: ...
+
+    @abstractmethod
+    def get_row(self, hash_id: str) -> Dict: ...
+
+    @abstractmethod
+    def get_rows(self, hash_ids: List[str]) -> Dict[str, Dict]: ...
+
+    @abstractmethod
+    def get_all_ids(self) -> List[str]: ...
+
+    @abstractmethod
+    def get_all_id_to_rows(self) -> Dict[str, Dict]: ...
+
+    @abstractmethod
+    def get_all_texts(self) -> Set[str]: ...
+
+    @abstractmethod
+    def get_embedding(self, hash_id: str, dtype=np.float32) -> np.ndarray: ...
+
+    @abstractmethod
+    def get_embeddings(self, hash_ids: List[str], dtype=np.float32) -> List[np.ndarray]: ...
+
+    def close(self) -> None:
+        """Release any held resources (connections, file locks). No-op by default."""
+
+
+class EmbeddingStore(BaseEmbeddingStore):
+    """Default backend: stores embeddings in a local Parquet file."""
+
+    def __init__(self, embedding_model, db_filename: str, batch_size: int, namespace: str):
         self.embedding_model = embedding_model
         self.batch_size = batch_size
         self.namespace = namespace
@@ -36,75 +94,68 @@ class EmbeddingStore:
             logger.info(f"Creating working directory: {db_filename}")
             os.makedirs(db_filename, exist_ok=True)
 
-        self.filename = os.path.join(
-            db_filename, f"vdb_{self.namespace}.parquet"
-        )
+        self.filename = os.path.join(db_filename, f"vdb_{self.namespace}.parquet")
         self._load_data()
 
     def get_missing_string_hash_ids(self, texts: List[str]):
         nodes_dict = {}
-
         for text in texts:
             nodes_dict[compute_mdhash_id(text, prefix=self.namespace + "-")] = {'content': text}
 
-        # Get all hash_ids from the input dictionary.
         all_hash_ids = list(nodes_dict.keys())
         if not all_hash_ids:
-            return  {}
+            return {}
 
         existing = self.hash_id_to_row.keys()
-
-        # Filter out the missing hash_ids.
         missing_ids = [hash_id for hash_id in all_hash_ids if hash_id not in existing]
         texts_to_encode = [nodes_dict[hash_id]["content"] for hash_id in missing_ids]
-
         return {h: {"hash_id": h, "content": t} for h, t in zip(missing_ids, texts_to_encode)}
 
     def insert_strings(self, texts: List[str]):
         nodes_dict = {}
-
         for text in texts:
             nodes_dict[compute_mdhash_id(text, prefix=self.namespace + "-")] = {'content': text}
 
-        # Get all hash_ids from the input dictionary.
         all_hash_ids = list(nodes_dict.keys())
         if not all_hash_ids:
-            return  # Nothing to insert.
+            return
 
         existing = self.hash_id_to_row.keys()
-
-        # Filter out the missing hash_ids.
         missing_ids = [hash_id for hash_id in all_hash_ids if hash_id not in existing]
 
-        logger.info(
-            f"Inserting {len(missing_ids)} new records, {len(all_hash_ids) - len(missing_ids)} records already exist.")
+        logger.info(f"Inserting {len(missing_ids)} new records, "
+                    f"{len(all_hash_ids) - len(missing_ids)} records already exist.")
 
         if not missing_ids:
-            return  {}# All records already exist.
+            return
 
-        # Prepare the texts to encode from the "content" field.
         texts_to_encode = [nodes_dict[hash_id]["content"] for hash_id in missing_ids]
-
         missing_embeddings = self.embedding_model.batch_encode(texts_to_encode)
-
         self._upsert(missing_ids, texts_to_encode, missing_embeddings)
 
     def _load_data(self):
         if os.path.exists(self.filename):
             df = pd.read_parquet(self.filename)
-            self.hash_ids, self.texts, self.embeddings = df["hash_id"].values.tolist(), df["content"].values.tolist(), df["embedding"].values.tolist()
+            self.hash_ids = df["hash_id"].values.tolist()
+            self.texts = df["content"].values.tolist()
+            self.embeddings = df["embedding"].values.tolist()
             self.hash_id_to_idx = {h: idx for idx, h in enumerate(self.hash_ids)}
             self.hash_id_to_row = {
                 h: {"hash_id": h, "content": t}
                 for h, t in zip(self.hash_ids, self.texts)
             }
             self.hash_id_to_text = {h: self.texts[idx] for idx, h in enumerate(self.hash_ids)}
-            self.text_to_hash_id = {self.texts[idx]: h  for idx, h in enumerate(self.hash_ids)}
+            self.text_to_hash_id = {self.texts[idx]: h for idx, h in enumerate(self.hash_ids)}
             assert len(self.hash_ids) == len(self.texts) == len(self.embeddings)
             logger.info(f"Loaded {len(self.hash_ids)} records from {self.filename}")
         else:
-            self.hash_ids, self.texts, self.embeddings = [], [], []
-            self.hash_id_to_idx, self.hash_id_to_row = {}, {}
+            self.hash_ids = []
+            self.texts = []
+            self.embeddings = []
+            self.hash_id_to_idx = {}
+            self.hash_id_to_row = {}
+            self.hash_id_to_text = {}
+            self.text_to_hash_id = {}
 
     def _save_data(self):
         data_to_save = pd.DataFrame({
@@ -113,7 +164,10 @@ class EmbeddingStore:
             "embedding": self.embeddings
         })
         data_to_save.to_parquet(self.filename, index=False)
-        self.hash_id_to_row = {h: {"hash_id": h, "content": t} for h, t, e in zip(self.hash_ids, self.texts, self.embeddings)}
+        self.hash_id_to_row = {
+            h: {"hash_id": h, "content": t}
+            for h, t, e in zip(self.hash_ids, self.texts, self.embeddings)
+        }
         self.hash_id_to_idx = {h: idx for idx, h in enumerate(self.hash_ids)}
         self.hash_id_to_text = {h: self.texts[idx] for idx, h in enumerate(self.hash_ids)}
         self.text_to_hash_id = {self.texts[idx]: h for idx, h in enumerate(self.hash_ids)}
@@ -123,57 +177,75 @@ class EmbeddingStore:
         self.embeddings.extend(embeddings)
         self.hash_ids.extend(hash_ids)
         self.texts.extend(texts)
-
         logger.info(f"Saving new records.")
         self._save_data()
 
     def delete(self, hash_ids):
-        indices = []
-
-        for hash in hash_ids:
-            indices.append(self.hash_id_to_idx[hash])
-
+        indices = [self.hash_id_to_idx[h] for h in hash_ids]
         sorted_indices = np.sort(indices)[::-1]
-
         for idx in sorted_indices:
             self.hash_ids.pop(idx)
             self.texts.pop(idx)
             self.embeddings.pop(idx)
-
         logger.info(f"Saving record after deletion.")
         self._save_data()
 
-    def get_row(self, hash_id):
+    def get_row(self, hash_id: str) -> Dict:
         return self.hash_id_to_row[hash_id]
 
-    def get_hash_id(self, text):
+    def get_hash_id(self, text: str) -> str:
         return self.text_to_hash_id[text]
 
-    def get_rows(self, hash_ids, dtype=np.float32):
+    def get_rows(self, hash_ids: List[str], dtype=np.float32) -> Dict[str, Dict]:
         if not hash_ids:
             return {}
+        return {id_: self.hash_id_to_row[id_] for id_ in hash_ids}
 
-        results = {id : self.hash_id_to_row[id] for id in hash_ids}
-
-        return results
-
-    def get_all_ids(self):
+    def get_all_ids(self) -> List[str]:
         return deepcopy(self.hash_ids)
 
-    def get_all_id_to_rows(self):
+    def get_all_id_to_rows(self) -> Dict[str, Dict]:
         return deepcopy(self.hash_id_to_row)
 
-    def get_all_texts(self):
+    def get_all_texts(self) -> Set[str]:
         return set(row['content'] for row in self.hash_id_to_row.values())
 
-    def get_embedding(self, hash_id, dtype=np.float32) -> np.ndarray:
+    def get_embedding(self, hash_id: str, dtype=np.float32) -> np.ndarray:
         return self.embeddings[self.hash_id_to_idx[hash_id]].astype(dtype)
-    
-    def get_embeddings(self, hash_ids, dtype=np.float32) -> list[np.ndarray]:
+
+    def get_embeddings(self, hash_ids: List[str], dtype=np.float32) -> List[np.ndarray]:
         if not hash_ids:
             return []
-
         indices = np.array([self.hash_id_to_idx[h] for h in hash_ids], dtype=np.intp)
         embeddings = np.array(self.embeddings, dtype=dtype)[indices]
-
         return embeddings
+
+
+def get_embedding_store(
+    embedding_model,
+    db_path: str,
+    batch_size: int,
+    namespace: str,
+    global_config=None,
+) -> BaseEmbeddingStore:
+    """
+    Factory that returns the appropriate EmbeddingStore backend based on
+    ``global_config.vector_store_type``.
+
+    Defaults to the local Parquet backend when no config is supplied.
+    """
+    store_type = getattr(global_config, "vector_store_type", "parquet") if global_config else "parquet"
+
+    if store_type == "parquet":
+        return EmbeddingStore(embedding_model, db_path, batch_size, namespace)
+    elif store_type == "qdrant":
+        from .vector_stores.qdrant_store import QdrantEmbeddingStore
+        return QdrantEmbeddingStore(embedding_model, db_path, batch_size, namespace, global_config)
+    elif store_type == "chroma":
+        from .vector_stores.chroma_store import ChromaEmbeddingStore
+        return ChromaEmbeddingStore(embedding_model, db_path, batch_size, namespace, global_config)
+    else:
+        raise ValueError(
+            f"Unknown vector_store_type: '{store_type}'. "
+            f"Choose from 'parquet', 'qdrant', or 'chroma'."
+        )

--- a/src/hipporag/utils/config_utils.py
+++ b/src/hipporag/utils/config_utils.py
@@ -198,6 +198,37 @@ class BaseConfig:
         default=None,
         metadata={"help": "Directory to save all related information. If it's given, will overwrite all default save_dir setups. If it's not given, then if we're not running specific datasets, default to `outputs`, otherwise, default to a dataset-customized output dir."}
     )
+
+    # Vector store backend
+    vector_store_type: Literal["parquet", "qdrant", "chroma"] = field(
+        default="parquet",
+        metadata={"help": "Which embedding store backend to use. "
+                  "'parquet' (default) stores embeddings in local Parquet files. "
+                  "'qdrant' uses a Qdrant vector database (local file or remote). "
+                  "'chroma' uses a ChromaDB collection (local file or remote HTTP)."}
+    )
+
+    # Qdrant-specific settings (only used when vector_store_type='qdrant')
+    qdrant_url: Optional[str] = field(
+        default=None,
+        metadata={"help": "URL of a remote Qdrant server (e.g. 'http://localhost:6333'). "
+                  "If None, a local file-based Qdrant store is used inside save_dir."}
+    )
+    qdrant_api_key: Optional[str] = field(
+        default=None,
+        metadata={"help": "API key for Qdrant Cloud or a secured remote Qdrant instance."}
+    )
+
+    # ChromaDB-specific settings (only used when vector_store_type='chroma')
+    chroma_host: Optional[str] = field(
+        default=None,
+        metadata={"help": "Hostname of a remote ChromaDB HTTP server. "
+                  "If None, a local persistent ChromaDB store is used inside save_dir."}
+    )
+    chroma_port: int = field(
+        default=8000,
+        metadata={"help": "Port of the remote ChromaDB HTTP server."}
+    )
     
     
     

--- a/src/hipporag/vector_stores/__init__.py
+++ b/src/hipporag/vector_stores/__init__.py
@@ -1,0 +1,4 @@
+from .qdrant_store import QdrantEmbeddingStore
+from .chroma_store import ChromaEmbeddingStore
+
+__all__ = ["QdrantEmbeddingStore", "ChromaEmbeddingStore"]

--- a/src/hipporag/vector_stores/chroma_store.py
+++ b/src/hipporag/vector_stores/chroma_store.py
@@ -1,0 +1,200 @@
+"""
+ChromaDB-backed embedding store for HippoRAG.
+
+Requires:
+    pip install chromadb
+
+Supports both local (persistent file) and remote (HTTP) ChromaDB:
+
+    # Local — no server needed
+    HippoRAG(..., vector_store_type="chroma")
+
+    # Remote
+    HippoRAG(..., vector_store_type="chroma",
+              chroma_host="localhost", chroma_port=8000)
+"""
+from __future__ import annotations
+
+import logging
+import os
+from copy import deepcopy
+from typing import Any, Dict, List, Optional, Set
+
+import numpy as np
+
+from ..embedding_store import BaseEmbeddingStore, compute_mdhash_id
+
+logger = logging.getLogger(__name__)
+
+
+def _get_chroma_client(db_path: str, global_config):
+    try:
+        import chromadb
+    except ImportError as exc:
+        raise ImportError(
+            "chromadb is required for the Chroma backend. "
+            "Install it with:  pip install chromadb"
+        ) from exc
+
+    host = getattr(global_config, "chroma_host", None)
+    port = getattr(global_config, "chroma_port", 8000)
+
+    if host:
+        logger.info(f"Connecting to remote ChromaDB at {host}:{port}")
+        return chromadb.HttpClient(host=host, port=port)
+    else:
+        chroma_dir = os.path.join(db_path, "chroma_storage")
+        os.makedirs(chroma_dir, exist_ok=True)
+        logger.info(f"Using local ChromaDB at {chroma_dir}")
+        return chromadb.PersistentClient(path=chroma_dir)
+
+
+class ChromaEmbeddingStore(BaseEmbeddingStore):
+    """
+    Embedding store backed by ChromaDB.
+
+    ChromaDB natively supports arbitrary string IDs, which maps perfectly to
+    HippoRAG's MD5-based hash IDs — no ID conversion needed.
+
+    Each (db_path, namespace) pair gets its own ChromaDB collection.
+    """
+
+    def __init__(
+        self,
+        embedding_model,
+        db_path: str,
+        batch_size: int,
+        namespace: str,
+        global_config=None,
+    ):
+        self.embedding_model = embedding_model
+        self.batch_size = batch_size
+        self.namespace = namespace
+        self.global_config = global_config
+
+        self.client = _get_chroma_client(db_path, global_config)
+
+        # ChromaDB collection name must be 3-63 chars, only [a-zA-Z0-9._-]
+        # We use a sanitised version of the namespace.
+        safe_ns = namespace.replace("-", "_")
+        self.collection_name = f"hipporag_{safe_ns}"
+
+        # We disable ChromaDB's built-in embedding — HippoRAG provides vectors.
+        self.collection = self.client.get_or_create_collection(
+            name=self.collection_name,
+            metadata={"hnsw:space": "cosine"},
+            embedding_function=None,
+        )
+
+        # In-memory caches kept in sync with every insert/delete
+        self.text_to_hash_id: Dict[str, str] = {}
+        self._hash_id_to_row: Dict[str, Dict] = {}
+
+        self._load_caches()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _load_caches(self):
+        """Populate in-memory dicts from the existing ChromaDB collection."""
+        try:
+            # get() with no filter returns all records (may be slow on huge collections)
+            result = self.collection.get(include=["documents"])
+        except Exception as exc:
+            logger.warning(f"Could not load existing Chroma records: {exc}")
+            return
+
+        for hash_id, content in zip(result["ids"], result["documents"]):
+            self._hash_id_to_row[hash_id] = {"hash_id": hash_id, "content": content}
+            self.text_to_hash_id[content] = hash_id
+
+        logger.info(
+            f"Loaded {len(self._hash_id_to_row)} records from ChromaDB "
+            f"collection '{self.collection_name}'."
+        )
+
+    # ------------------------------------------------------------------
+    # BaseEmbeddingStore interface
+    # ------------------------------------------------------------------
+
+    def insert_strings(self, texts: List[str]) -> None:
+        nodes_dict = {
+            compute_mdhash_id(t, prefix=self.namespace + "-"): t for t in texts
+        }
+        missing_ids = [h for h in nodes_dict if h not in self._hash_id_to_row]
+
+        logger.info(
+            f"Inserting {len(missing_ids)} new records, "
+            f"{len(nodes_dict) - len(missing_ids)} already exist."
+        )
+        if not missing_ids:
+            return
+
+        texts_to_encode = [nodes_dict[h] for h in missing_ids]
+        embeddings = self.embedding_model.batch_encode(texts_to_encode)
+
+        # Upsert in batches
+        for i in range(0, len(missing_ids), self.batch_size):
+            batch_ids = missing_ids[i : i + self.batch_size]
+            batch_texts = texts_to_encode[i : i + self.batch_size]
+            batch_embs = embeddings[i : i + self.batch_size]
+
+            self.collection.add(
+                ids=batch_ids,
+                documents=batch_texts,
+                embeddings=[np.array(e).astype(np.float32).tolist() for e in batch_embs],
+            )
+
+        # Update caches
+        for h, text in zip(missing_ids, texts_to_encode):
+            self._hash_id_to_row[h] = {"hash_id": h, "content": text}
+            self.text_to_hash_id[text] = h
+
+        logger.info(f"Inserted {len(missing_ids)} records into '{self.collection_name}'.")
+
+    def delete(self, hash_ids) -> None:
+        hash_ids = list(hash_ids)
+        self.collection.delete(ids=hash_ids)
+
+        for h in hash_ids:
+            row = self._hash_id_to_row.pop(h, None)
+            if row is not None:
+                self.text_to_hash_id.pop(row["content"], None)
+
+        logger.info(f"Deleted {len(hash_ids)} records from '{self.collection_name}'.")
+
+    def get_row(self, hash_id: str) -> Dict:
+        return self._hash_id_to_row[hash_id]
+
+    def get_rows(self, hash_ids: List[str]) -> Dict[str, Dict]:
+        return {h: self._hash_id_to_row[h] for h in hash_ids if h in self._hash_id_to_row}
+
+    def get_all_ids(self) -> List[str]:
+        return list(self._hash_id_to_row.keys())
+
+    def get_all_id_to_rows(self) -> Dict[str, Dict]:
+        return deepcopy(self._hash_id_to_row)
+
+    def get_all_texts(self) -> Set[str]:
+        return {row["content"] for row in self._hash_id_to_row.values()}
+
+    def get_embedding(self, hash_id: str, dtype=np.float32) -> np.ndarray:
+        result = self.collection.get(ids=[hash_id], include=["embeddings"])
+        if not result["ids"]:
+            raise KeyError(f"hash_id '{hash_id}' not found in ChromaDB.")
+        return np.array(result["embeddings"][0], dtype=dtype)
+
+    def get_embeddings(self, hash_ids: List[str], dtype=np.float32) -> np.ndarray:
+        if not hash_ids:
+            return np.array([])
+
+        # Retrieve in batches, then reassemble in the original order
+        id_to_emb: Dict[str, np.ndarray] = {}
+        for i in range(0, len(hash_ids), self.batch_size):
+            batch = hash_ids[i : i + self.batch_size]
+            result = self.collection.get(ids=batch, include=["embeddings"])
+            for h, emb in zip(result["ids"], result["embeddings"]):
+                id_to_emb[h] = np.array(emb, dtype=dtype)
+
+        return np.array([id_to_emb[h] for h in hash_ids], dtype=dtype)

--- a/src/hipporag/vector_stores/qdrant_store.py
+++ b/src/hipporag/vector_stores/qdrant_store.py
@@ -1,0 +1,296 @@
+"""
+Qdrant-backed embedding store for HippoRAG.
+
+Requires:
+    pip install qdrant-client
+
+Supports both local (file-based) and remote Qdrant deployments:
+
+    # Local — no server needed
+    HippoRAG(..., vector_store_type="qdrant")
+
+    # Remote
+    HippoRAG(..., vector_store_type="qdrant",
+              qdrant_url="http://localhost:6333",
+              qdrant_api_key="<key>")
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from copy import deepcopy
+from typing import Any, Dict, List, Optional, Set
+
+import numpy as np
+
+from ..embedding_store import BaseEmbeddingStore, compute_mdhash_id
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Helper: convert a HippoRAG hash-ID to a Qdrant-compatible UUID string.
+# Qdrant point IDs must be unsigned integers or UUID v1/v4/v5 strings.
+# We derive a deterministic UUID v5 from the hash_id so we never need to
+# store a separate mapping from UUID → hash_id inside Qdrant.
+# ---------------------------------------------------------------------------
+_UUID_NS = uuid.UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")  # uuid.NAMESPACE_URL
+
+
+def _to_qdrant_id(hash_id: str) -> str:
+    return str(uuid.uuid5(_UUID_NS, hash_id))
+
+
+def _get_qdrant_client(global_config):
+    try:
+        from qdrant_client import QdrantClient
+    except ImportError as exc:
+        raise ImportError(
+            "qdrant-client is required for the Qdrant backend. "
+            "Install it with:  pip install qdrant-client"
+        ) from exc
+
+    url = getattr(global_config, "qdrant_url", None)
+    api_key = getattr(global_config, "qdrant_api_key", None)
+
+    if url:
+        logger.info(f"Connecting to remote Qdrant at {url}")
+        return QdrantClient(url=url, api_key=api_key)
+    else:
+        # Default: local file-based mode (no server required)
+        return QdrantClient(path=getattr(global_config, "qdrant_path", None))
+
+
+class QdrantEmbeddingStore(BaseEmbeddingStore):
+    """
+    Embedding store backed by Qdrant.
+
+    Each (save_dir, namespace) pair maps to its own Qdrant collection so
+    chunk / entity / fact embeddings stay isolated.
+    """
+
+    def __init__(
+        self,
+        embedding_model,
+        db_path: str,
+        batch_size: int,
+        namespace: str,
+        global_config=None,
+    ):
+        self.embedding_model = embedding_model
+        self.batch_size = batch_size
+        self.namespace = namespace
+        self.global_config = global_config
+
+        # Derive a short unique collection name from path + namespace.
+        # We hash the path so the name stays valid on all OSes (no colons, slashes, etc.)
+        import hashlib
+        path_hash = hashlib.md5(db_path.encode()).hexdigest()[:16]
+        self.collection_name = f"hipporag_{path_hash}_{namespace}"
+
+        # Build the client; for local mode use db_path as the storage dir
+        if global_config and not getattr(global_config, "qdrant_url", None):
+            try:
+                from qdrant_client import QdrantClient
+            except ImportError as exc:
+                raise ImportError(
+                    "qdrant-client is required for the Qdrant backend. "
+                    "Install it with:  pip install qdrant-client"
+                ) from exc
+            import os
+            qdrant_dir = os.path.join(db_path, "qdrant_storage")
+            os.makedirs(qdrant_dir, exist_ok=True)
+            self.client = QdrantClient(path=qdrant_dir)
+        else:
+            self.client = _get_qdrant_client(global_config)
+
+        # In-memory caches (rebuilt from Qdrant on init)
+        self.text_to_hash_id: Dict[str, str] = {}
+        self._hash_id_to_text: Dict[str, str] = {}
+        self._hash_id_to_row: Dict[str, Dict] = {}
+
+        self._init_collection()
+        self._load_caches()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _init_collection(self):
+        """Create the Qdrant collection if it doesn't already exist."""
+        from qdrant_client.models import Distance, VectorParams
+
+        existing = {c.name for c in self.client.get_collections().collections}
+        if self.collection_name not in existing:
+            # Dimension is unknown until the first insert; we create the
+            # collection lazily in _ensure_collection_for_dim().
+            logger.info(
+                f"Qdrant collection '{self.collection_name}' will be created on first insert."
+            )
+
+    def _ensure_collection(self, dim: int):
+        """Create collection with the correct vector dimension if needed."""
+        from qdrant_client.models import Distance, VectorParams
+
+        existing = {c.name for c in self.client.get_collections().collections}
+        if self.collection_name not in existing:
+            self.client.create_collection(
+                collection_name=self.collection_name,
+                vectors_config=VectorParams(size=dim, distance=Distance.COSINE),
+            )
+            logger.info(
+                f"Created Qdrant collection '{self.collection_name}' with dim={dim}."
+            )
+
+    def _load_caches(self):
+        """Scroll all points from Qdrant and rebuild in-memory dicts."""
+        from qdrant_client.models import Filter
+
+        existing = {c.name for c in self.client.get_collections().collections}
+        if self.collection_name not in existing:
+            return  # Nothing to load yet
+
+        offset = None
+        while True:
+            result, next_offset = self.client.scroll(
+                collection_name=self.collection_name,
+                limit=1000,
+                offset=offset,
+                with_vectors=False,
+                with_payload=True,
+            )
+            for point in result:
+                hash_id = point.payload["hash_id"]
+                content = point.payload["content"]
+                self._hash_id_to_text[hash_id] = content
+                self._hash_id_to_row[hash_id] = {"hash_id": hash_id, "content": content}
+                self.text_to_hash_id[content] = hash_id
+
+            if next_offset is None:
+                break
+            offset = next_offset
+
+        logger.info(
+            f"Loaded {len(self._hash_id_to_row)} records from Qdrant "
+            f"collection '{self.collection_name}'."
+        )
+
+    # ------------------------------------------------------------------
+    # BaseEmbeddingStore interface
+    # ------------------------------------------------------------------
+
+    def insert_strings(self, texts: List[str]) -> None:
+        from qdrant_client.models import PointStruct
+
+        nodes_dict = {
+            compute_mdhash_id(t, prefix=self.namespace + "-"): t for t in texts
+        }
+        missing_ids = [h for h in nodes_dict if h not in self._hash_id_to_row]
+
+        logger.info(
+            f"Inserting {len(missing_ids)} new records, "
+            f"{len(nodes_dict) - len(missing_ids)} already exist."
+        )
+        if not missing_ids:
+            return
+
+        texts_to_encode = [nodes_dict[h] for h in missing_ids]
+        embeddings = self.embedding_model.batch_encode(texts_to_encode)
+
+        if len(missing_ids) > 0:
+            dim = len(embeddings[0]) if hasattr(embeddings[0], "__len__") else embeddings.shape[1]
+            self._ensure_collection(dim)
+
+        points = [
+            PointStruct(
+                id=_to_qdrant_id(h),
+                vector=np.array(emb).astype(np.float32).tolist(),
+                payload={"hash_id": h, "content": text},
+            )
+            for h, text, emb in zip(missing_ids, texts_to_encode, embeddings)
+        ]
+
+        # Upsert in batches to avoid overloading the client
+        for i in range(0, len(points), self.batch_size):
+            self.client.upsert(
+                collection_name=self.collection_name,
+                points=points[i : i + self.batch_size],
+            )
+
+        # Update in-memory caches
+        for h, text in zip(missing_ids, texts_to_encode):
+            self._hash_id_to_text[h] = text
+            self._hash_id_to_row[h] = {"hash_id": h, "content": text}
+            self.text_to_hash_id[text] = h
+
+        logger.info(f"Upserted {len(points)} points to '{self.collection_name}'.")
+
+    def delete(self, hash_ids) -> None:
+        from qdrant_client.models import PointIdsList
+
+        hash_ids = list(hash_ids)
+        qdrant_ids = [_to_qdrant_id(h) for h in hash_ids]
+
+        self.client.delete(
+            collection_name=self.collection_name,
+            points_selector=PointIdsList(points=qdrant_ids),
+        )
+
+        for h in hash_ids:
+            text = self._hash_id_to_text.pop(h, None)
+            self._hash_id_to_row.pop(h, None)
+            if text is not None:
+                self.text_to_hash_id.pop(text, None)
+
+        logger.info(f"Deleted {len(hash_ids)} points from '{self.collection_name}'.")
+
+    def get_row(self, hash_id: str) -> Dict:
+        return self._hash_id_to_row[hash_id]
+
+    def get_rows(self, hash_ids: List[str]) -> Dict[str, Dict]:
+        return {h: self._hash_id_to_row[h] for h in hash_ids if h in self._hash_id_to_row}
+
+    def get_all_ids(self) -> List[str]:
+        return list(self._hash_id_to_row.keys())
+
+    def get_all_id_to_rows(self) -> Dict[str, Dict]:
+        return deepcopy(self._hash_id_to_row)
+
+    def get_all_texts(self) -> Set[str]:
+        return set(self._hash_id_to_text.values())
+
+    def get_embedding(self, hash_id: str, dtype=np.float32) -> np.ndarray:
+        result = self.client.retrieve(
+            collection_name=self.collection_name,
+            ids=[_to_qdrant_id(hash_id)],
+            with_vectors=True,
+            with_payload=False,
+        )
+        if not result:
+            raise KeyError(f"hash_id '{hash_id}' not found in Qdrant.")
+        return np.array(result[0].vector, dtype=dtype)
+
+    def close(self) -> None:
+        """Release the Qdrant client's file lock so another instance can open the same path."""
+        self.client.close()
+
+    def get_embeddings(self, hash_ids: List[str], dtype=np.float32) -> np.ndarray:
+        if not hash_ids:
+            return np.array([])
+
+        qdrant_ids = [_to_qdrant_id(h) for h in hash_ids]
+        # Retrieve in batches for large collections
+        all_results: Dict[str, Any] = {}
+        for i in range(0, len(qdrant_ids), self.batch_size):
+            batch = qdrant_ids[i : i + self.batch_size]
+            records = self.client.retrieve(
+                collection_name=self.collection_name,
+                ids=batch,
+                with_vectors=True,
+                with_payload=False,
+            )
+            for rec in records:
+                all_results[rec.id] = rec.vector
+
+        # Return in the same order as hash_ids
+        ordered = [all_results[_to_qdrant_id(h)] for h in hash_ids]
+        return np.array(ordered, dtype=dtype)

--- a/tests_vector_stores.py
+++ b/tests_vector_stores.py
@@ -1,0 +1,314 @@
+"""
+Tests for vector store backends (Parquet, Qdrant, ChromaDB).
+
+No OpenAI key or GPU required -- a deterministic MockEmbeddingModel is used.
+
+Usage
+-----
+# All backends (skip Qdrant/Chroma if packages not installed)
+python tests_vector_stores.py
+
+# Install optional backends first:
+pip install qdrant-client   # for Qdrant tests
+pip install chromadb        # for Chroma tests
+"""
+
+import os
+import sys
+import shutil
+import tempfile
+import traceback
+import importlib
+from typing import List
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Mock embedding model -- returns stable random vectors, no GPU needed
+# ---------------------------------------------------------------------------
+
+EMBEDDING_DIM = 64
+
+
+class MockEmbeddingModel:
+    """Returns deterministic fixed-size embeddings based on text hash."""
+
+    def batch_encode(self, texts: List[str], **kwargs) -> np.ndarray:
+        results = []
+        for text in texts:
+            rng = np.random.default_rng(seed=abs(hash(text)) % (2**32))
+            vec = rng.random(EMBEDDING_DIM).astype(np.float32)
+            vec /= np.linalg.norm(vec)
+            results.append(vec)
+        return np.array(results)
+
+
+EMBEDDING_MODEL = MockEmbeddingModel()
+
+# ---------------------------------------------------------------------------
+# Shared test data
+# ---------------------------------------------------------------------------
+
+DOCS = [
+    "Oliver Badman is a politician.",
+    "George Rankin is a politician.",
+    "Thomas Marwick is a politician.",
+    "Cinderella attended the royal ball.",
+    "The prince used the lost glass slipper to search the kingdom.",
+    "When the slipper fit perfectly, Cinderella was reunited with the prince.",
+    "Erik Hort's birthplace is Montebello.",
+    "Marina is born in Minsk.",
+    "Montebello is a part of Rockland County.",
+]
+
+EXTRA_DOCS = [
+    "Tom Hort's birthplace is Montebello.",
+    "Sam Hort's birthplace is Montebello.",
+]
+
+# ---------------------------------------------------------------------------
+# Common test logic -- backend-agnostic
+# ---------------------------------------------------------------------------
+
+def _run_store_tests(store, label: str):
+    """Run the full insert / query / delete test suite on any store backend."""
+    print(f"\n  [1] Insert {len(DOCS)} documents ...", end=" ")
+    store.insert_strings(DOCS)
+    ids = store.get_all_ids()
+    assert len(ids) == len(DOCS), f"Expected {len(DOCS)} IDs, got {len(ids)}"
+    print("OK")
+
+    print("  [2] No-op re-insert (idempotency) ...", end=" ")
+    store.insert_strings(DOCS)
+    assert len(store.get_all_ids()) == len(DOCS), "Re-insert must not create duplicates"
+    print("OK")
+
+    print("  [3] get_all_texts ...", end=" ")
+    texts = store.get_all_texts()
+    assert set(DOCS) == texts, "get_all_texts mismatch"
+    print("OK")
+
+    print("  [4] text_to_hash_id lookup ...", end=" ")
+    first_doc = DOCS[0]
+    hid = store.text_to_hash_id[first_doc]
+    assert isinstance(hid, str) and len(hid) > 0
+    print("OK")
+
+    print("  [5] get_row / get_rows ...", end=" ")
+    row = store.get_row(hid)
+    assert row["content"] == first_doc
+    rows = store.get_rows([hid])
+    assert rows[hid]["content"] == first_doc
+    print("OK")
+
+    print("  [6] get_embeddings order & shape ...", end=" ")
+    all_ids = store.get_all_ids()
+    embs = store.get_embeddings(all_ids)
+    assert embs.shape == (len(DOCS), EMBEDDING_DIM), (
+        f"Shape mismatch: {embs.shape} vs expected ({len(DOCS)}, {EMBEDDING_DIM})"
+    )
+    print("OK")
+
+    print("  [7] get_embedding single ...", end=" ")
+    single = store.get_embedding(hid)
+    assert single.shape == (EMBEDDING_DIM,)
+    print("OK")
+
+    print("  [8] get_missing_string_hash_ids ...", end=" ")
+    new_texts = DOCS[:2] + EXTRA_DOCS
+    missing = store.get_missing_string_hash_ids(new_texts)
+    assert len(missing) == len(EXTRA_DOCS), (
+        f"Expected {len(EXTRA_DOCS)} missing, got {len(missing)}"
+    )
+    print("OK")
+
+    print(f"  [9] Incremental insert ({len(EXTRA_DOCS)} new docs) ...", end=" ")
+    store.insert_strings(EXTRA_DOCS)
+    assert len(store.get_all_ids()) == len(DOCS) + len(EXTRA_DOCS)
+    print("OK")
+
+    print("  [10] Delete extra docs ...", end=" ")
+    ids_to_delete = [store.text_to_hash_id[t] for t in EXTRA_DOCS]
+    store.delete(ids_to_delete)
+    assert len(store.get_all_ids()) == len(DOCS)
+    for t in EXTRA_DOCS:
+        assert t not in store.text_to_hash_id
+    print("OK")
+
+
+def _test_persistence(make_store, label: str):
+    """Verify that data survives a store teardown and reload."""
+    print(f"\n  [11] Persistence (save -> reload) ...", end=" ")
+    store1 = make_store()
+    store1.insert_strings(DOCS)
+    ids_before = set(store1.get_all_ids())
+
+    # Close before reopening -- required for backends that hold file locks (e.g. Qdrant local)
+    store1.close()
+
+    store2 = make_store()  # fresh instance, same path -- should reload
+    ids_after = set(store2.get_all_ids())
+    assert ids_before == ids_after, (
+        f"IDs changed after reload:\n  before={ids_before}\n  after={ids_after}"
+    )
+    print("OK")
+
+
+# ---------------------------------------------------------------------------
+# Per-backend test runners
+# ---------------------------------------------------------------------------
+
+def test_parquet(tmp_dir: str):
+    from src.hipporag.embedding_store import EmbeddingStore
+
+    label = "Parquet"
+    print(f"\n{'='*55}")
+    print(f"  Backend: {label}")
+    print(f"{'='*55}")
+
+    db_path = os.path.join(tmp_dir, "parquet", "chunk_embeddings")
+    store = EmbeddingStore(EMBEDDING_MODEL, db_path, batch_size=16, namespace="chunk")
+    _run_store_tests(store, label)
+
+    def make_store():
+        return EmbeddingStore(EMBEDDING_MODEL, db_path, batch_size=16, namespace="chunk")
+
+    _test_persistence(make_store, label)
+    print(f"\n  PASS: {label} -- all tests passed")
+
+
+def test_qdrant(tmp_dir: str):
+    if importlib.util.find_spec("qdrant_client") is None:
+        print("\n  [SKIP] Qdrant -- qdrant-client not installed  (pip install qdrant-client)")
+        return
+
+    from src.hipporag.vector_stores.qdrant_store import QdrantEmbeddingStore
+
+    label = "Qdrant (local)"
+    print(f"\n{'='*55}")
+    print(f"  Backend: {label}")
+    print(f"{'='*55}")
+
+    db_path = os.path.join(tmp_dir, "qdrant", "chunk_embeddings")
+
+    class _FakeConfig:
+        qdrant_url = None  # use local file mode
+
+    cfg = _FakeConfig()
+    store = QdrantEmbeddingStore(EMBEDDING_MODEL, db_path, batch_size=16, namespace="chunk", global_config=cfg)
+    _run_store_tests(store, label)
+    store.close()  # release file lock before persistence test opens the same path
+
+    def make_store():
+        return QdrantEmbeddingStore(EMBEDDING_MODEL, db_path, batch_size=16, namespace="chunk", global_config=cfg)
+
+    _test_persistence(make_store, label)
+    print(f"\n  PASS: {label} -- all tests passed")
+
+
+def test_chroma(tmp_dir: str):
+    if importlib.util.find_spec("chromadb") is None:
+        print("\n  [SKIP] ChromaDB -- chromadb not installed  (pip install chromadb)")
+        return
+
+    from src.hipporag.vector_stores.chroma_store import ChromaEmbeddingStore
+
+    label = "ChromaDB (local)"
+    print(f"\n{'='*55}")
+    print(f"  Backend: {label}")
+    print(f"{'='*55}")
+
+    db_path = os.path.join(tmp_dir, "chroma", "chunk_embeddings")
+
+    class _FakeConfig:
+        chroma_host = None  # use local persistent mode
+        chroma_port = 8000
+
+    cfg = _FakeConfig()
+    store = ChromaEmbeddingStore(EMBEDDING_MODEL, db_path, batch_size=16, namespace="chunk", global_config=cfg)
+    _run_store_tests(store, label)
+
+    def make_store():
+        return ChromaEmbeddingStore(EMBEDDING_MODEL, db_path, batch_size=16, namespace="chunk", global_config=cfg)
+
+    _test_persistence(make_store, label)
+    print(f"\n  PASS: {label} -- all tests passed")
+
+
+def test_factory(tmp_dir: str):
+    """Verify get_embedding_store() returns the right class for each type."""
+    from src.hipporag.embedding_store import get_embedding_store, EmbeddingStore, BaseEmbeddingStore
+
+    print(f"\n{'='*55}")
+    print("  Factory: get_embedding_store()")
+    print(f"{'='*55}")
+
+    class _Config:
+        vector_store_type = "parquet"
+        qdrant_url = None
+        chroma_host = None
+        chroma_port = 8000
+
+    cfg = _Config()
+    store = get_embedding_store(EMBEDDING_MODEL, os.path.join(tmp_dir, "factory"), 16, "chunk", cfg)
+    assert isinstance(store, EmbeddingStore), f"Expected EmbeddingStore, got {type(store)}"
+    assert isinstance(store, BaseEmbeddingStore), "Must inherit BaseEmbeddingStore"
+    print("  [1] parquet -> EmbeddingStore  OK")
+
+    if importlib.util.find_spec("qdrant_client"):
+        from src.hipporag.vector_stores.qdrant_store import QdrantEmbeddingStore
+        cfg.vector_store_type = "qdrant"
+        store = get_embedding_store(EMBEDDING_MODEL, os.path.join(tmp_dir, "factory_qdrant"), 16, "chunk", cfg)
+        assert isinstance(store, QdrantEmbeddingStore)
+        print("  [2] qdrant  -> QdrantEmbeddingStore  OK")
+
+    if importlib.util.find_spec("chromadb"):
+        from src.hipporag.vector_stores.chroma_store import ChromaEmbeddingStore
+        cfg.vector_store_type = "chroma"
+        store = get_embedding_store(EMBEDDING_MODEL, os.path.join(tmp_dir, "factory_chroma"), 16, "chunk", cfg)
+        assert isinstance(store, ChromaEmbeddingStore)
+        print("  [3] chroma  -> ChromaEmbeddingStore  OK")
+
+    print(f"\n  PASS: Factory -- all checks passed")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main():
+    print("HippoRAG Vector Store Tests")
+    print(f"Python {sys.version}")
+
+    tmp_dir = tempfile.mkdtemp(prefix="hipporag_vstore_test_")
+    print(f"\nTemp directory: {tmp_dir}")
+
+    passed, failed = [], []
+
+    for name, fn in [
+        ("Parquet", test_parquet),
+        ("Qdrant", test_qdrant),
+        ("ChromaDB", test_chroma),
+        ("Factory", test_factory),
+    ]:
+        try:
+            fn(tmp_dir)
+            passed.append(name)
+        except Exception:
+            failed.append(name)
+            print(f"\n  FAIL: {name} FAILED:")
+            traceback.print_exc()
+
+    shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    print(f"\n{'='*55}")
+    print(f"Results: {len(passed)} passed, {len(failed)} failed")
+    if failed:
+        print(f"Failed:  {', '.join(failed)}")
+        sys.exit(1)
+    else:
+        print("All tests passed!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #<issue-number>

Implements pluggable vector database backends as discussed in the issue.

## Changes
- Add `BaseEmbeddingStore` ABC for pluggable backend support
- Add `QdrantEmbeddingStore` (local file or remote server)
- Add `ChromaEmbeddingStore` (local file or remote HTTP)
- Add `get_embedding_store()` factory; default Parquet backend unchanged
- Add `vector_store_type`, `qdrant_url`, `qdrant_api_key`, `chroma_host`, `chroma_port` to `BaseConfig`
- Fix `EmbeddingCache` multiprocessing crash on Windows (spawn-based processes)
- Fix unconditional `vllm` import (Linux-only, now lazy)

## Testing
pip install qdrant-client chromadb
python tests_vector_stores.py
# 4 backends x 11 checks — all passed

## Usage
# Default unchanged
HippoRAG(..., vector_store_type="parquet")  # or omit entirely

# Qdrant local
HippoRAG(..., vector_store_type="qdrant")

# ChromaDB local
HippoRAG(..., vector_store_type="chroma")
