### PR TITLE
feat: add OrcaRouter as a named LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,27 @@ hipporag = HippoRAG(
 
 The Mantle endpoint and model availability are region-specific. HippoRAG requires an explicit endpoint and raises an error if the Bedrock API key is missing. To use an existing AWS profile instead, construct a `BaseConfig` with `bedrock_mantle_auth='aws_credentials'`, `bedrock_aws_profile='<profile>'`, and `bedrock_region='<region>'`; this explicitly enables SigV4 authentication. Mantle response storage is disabled by default (`store=False`); pass `store=True` to `infer` only when server-side conversation state is required.
 
+### OrcaRouter
+
+OrcaRouter is an OpenAI-compatible AI gateway that routes HippoRAG's requests across models from OpenAI, Anthropic, Google Gemini, DeepSeek, and more through a single endpoint. Prefix the OrcaRouter model ID with `orcarouter/` to use it as a named provider, as shown in `examples/demo_orcarouter.py`:
+
+```sh
+export ORCAROUTER_API_KEY=<your OrcaRouter API key>
+python examples/demo_orcarouter.py
+```
+
+The corresponding configuration is:
+
+```python
+hipporag = HippoRAG(
+    save_dir='outputs/orcarouter',
+    llm_model_name='orcarouter/anthropic/claude-opus-4.8',
+    embedding_model_name=embedding_model_name,
+)
+```
+
+Model names use the `vendor/model` namespace (for example `orcarouter/anthropic/claude-opus-4.8` or `orcarouter/google/gemini-2.5-flash`), and `orcarouter/auto` lets the router pick a live model automatically. HippoRAG uses the default OrcaRouter endpoint `https://api.orcarouter.ai/v1`; set `llm_base_url` explicitly to override it.
+
 ### Local Deployment (vLLM)
 
 This simple example will illustrate how to use `hipporag` with any vLLM-compatible locally deployed LLM.
@@ -263,6 +284,7 @@ Provider integration scripts exercise indexing, graph reload, incremental update
 | --- | --- |
 | OpenAI | `python tests/integration/run_openai.py` |
 | Azure OpenAI | `python tests/integration/run_azure.py --azure_endpoint <resource-url> --azure_api_version <version> --azure_embedding_endpoint <resource-url>` |
+| OrcaRouter | `python tests/integration/run_orcarouter.py` |
 | Local vLLM | `python tests/integration/run_local.py` |
 | Transformers | `python tests/integration/run_transformers.py` |
 

--- a/examples/demo_orcarouter.py
+++ b/examples/demo_orcarouter.py
@@ -1,0 +1,17 @@
+from hipporag.llm import _get_llm_class
+from hipporag.utils.config_utils import BaseConfig
+
+
+def main():
+    config = BaseConfig(
+        llm_name="orcarouter/anthropic/claude-opus-4.8",
+        save_dir="outputs/orcarouter",
+    )
+    llm = _get_llm_class(config)
+    message, metadata, cached = llm.infer([{"role": "user", "content": "Reply with exactly: HippoRAG OrcaRouter test passed"}])
+    print(message)
+    print({"metadata": metadata, "cached": cached})
+
+
+if __name__ == "__main__":
+    main()

--- a/src/hipporag/HippoRAG.py
+++ b/src/hipporag/HippoRAG.py
@@ -358,6 +358,8 @@ class HippoRAG:
         elif self.global_config.openie_mode == "online" and self.global_config.llm_name.startswith("bedrock-mantle/"):
             endpoint = self.global_config.llm_base_url
             region = self.global_config.bedrock_region or os.getenv("AWS_REGION_NAME") or os.getenv("AWS_DEFAULT_REGION")
+        elif self.global_config.openie_mode == "online" and self.global_config.llm_name.startswith("orcarouter/"):
+            endpoint = self.global_config.llm_base_url or "https://api.orcarouter.ai/v1"
         elif self.global_config.openie_mode == "online" and not self.global_config.llm_name.startswith("Transformers/"):
             endpoint = self.global_config.azure_endpoint or self.global_config.llm_base_url or "https://api.openai.com/v1"
         if self.global_config.openie_mode == "online":

--- a/src/hipporag/llm/__init__.py
+++ b/src/hipporag/llm/__init__.py
@@ -5,6 +5,7 @@ from .openai_gpt import CacheOpenAI
 from .base import BaseLLM
 from .bedrock_llm import BedrockLLM
 from .bedrock_mantle import BedrockMantleLLM
+from .orcarouter_llm import OrcaRouterLLM
 from .transformers_llm import TransformersLLM
 
 
@@ -12,6 +13,9 @@ logger = get_logger(__name__)
 
 
 def _get_llm_class(config: BaseConfig):
+    if config.llm_name.startswith('orcarouter/'):
+        return OrcaRouterLLM(config)
+
     if config.llm_name.startswith('bedrock-mantle/'):
         return BedrockMantleLLM(config)
 

--- a/src/hipporag/llm/orcarouter_llm.py
+++ b/src/hipporag/llm/orcarouter_llm.py
@@ -1,0 +1,107 @@
+import os
+from typing import List, Tuple
+
+from openai import OpenAI
+
+from ..utils.config_utils import BaseConfig
+from ..utils.llm_utils import TextChatMessage
+from ..utils.logging_utils import get_logger
+from ..utils.openai_utils import validate_openai_base_url
+from .base import BaseLLM, LLMConfig, normalize_generation_token_params
+from .openai_gpt import cache_response
+
+logger = get_logger(__name__)
+
+DEFAULT_ORCAROUTER_BASE_URL = "https://api.orcarouter.ai/v1"
+
+
+class OrcaRouterLLM(BaseLLM):
+    """OrcaRouter implementation using the OpenAI Chat Completions API.
+
+    OrcaRouter exposes an OpenAI-compatible endpoint that routes requests across
+    many models. Model names use the ``vendor/model`` namespace (for example
+    ``anthropic/claude-opus-4.8``), and ``orcarouter/auto`` lets the router pick
+    a live model automatically.
+    """
+
+    prefix = "orcarouter/"
+
+    def __init__(self, global_config: BaseConfig) -> None:
+        super().__init__(global_config)
+        if not self.llm_name.startswith(self.prefix) or len(self.llm_name) == len(self.prefix):
+            raise ValueError(f"OrcaRouter model names must use {self.prefix}<vendor/model>.")
+        self.llm_base_url = validate_openai_base_url(
+            self.global_config.llm_base_url or DEFAULT_ORCAROUTER_BASE_URL,
+            "chat/completions",
+            "llm_base_url",
+        )
+        api_key = os.getenv("ORCAROUTER_API_KEY")
+        if not api_key:
+            raise ValueError("ORCAROUTER_API_KEY is required for OrcaRouter.")
+        self.cache_dir = os.path.join(global_config.save_dir, "llm_cache")
+        os.makedirs(self.cache_dir, exist_ok=True)
+        self.cache_file_name = os.path.join(self.cache_dir, f"{self.llm_name.replace('/', '_')}_cache.sqlite")
+        self.max_retries = global_config.max_retry_attempts
+        self._init_llm_config()
+        self.openai_client = OpenAI(
+            base_url=self.llm_base_url,
+            api_key=api_key,
+            max_retries=self.max_retries,
+            timeout=5 * 60,
+        )
+
+    def _init_llm_config(self) -> None:
+        generate_params = {
+            "model": self.llm_name[len(self.prefix):],
+        }
+        if self.global_config.max_new_tokens is not None:
+            generate_params["max_completion_tokens"] = self.global_config.max_new_tokens
+        if self.global_config.seed is not None:
+            generate_params["seed"] = self.global_config.seed
+        if self.global_config.temperature is not None:
+            generate_params["temperature"] = self.global_config.temperature
+        self.llm_config = LLMConfig.from_dict({
+            "llm_name": self.llm_name,
+            "llm_base_url": self.llm_base_url,
+            "generate_params": generate_params,
+        })
+
+    @cache_response
+    def infer(self, messages: List[TextChatMessage], **kwargs) -> Tuple[str, dict, bool]:
+        params = normalize_generation_token_params(self.llm_config.generate_params, kwargs, "max_completion_tokens")
+        params["messages"] = messages
+        logger.debug(f"Calling OrcaRouter Chat Completions API with model {params['model']}")
+        response = self.openai_client.chat.completions.create(**params)
+        if len(response.choices) != 1:
+            raise ValueError(f"HippoRAG expected exactly one OrcaRouter choice, received {len(response.choices)}.")
+        choice = response.choices[0]
+        response_message = choice.message.content
+        if not isinstance(response_message, str) or not response_message:
+            refusal = getattr(choice.message, "refusal", None)
+            detail = f" Refusal: {refusal}" if refusal else ""
+            raise ValueError(f"OrcaRouter response did not contain non-empty text.{detail}")
+        usage = response.usage
+        if usage is None:
+            raise ValueError("OrcaRouter response omitted usage; HippoRAG cannot account for this request safely.")
+        total_tokens = getattr(usage, "total_tokens", None)
+        metadata = {
+            "prompt_tokens": usage.prompt_tokens,
+            "completion_tokens": usage.completion_tokens,
+            "total_tokens": total_tokens if total_tokens is not None else usage.prompt_tokens + usage.completion_tokens,
+            "finish_reason": choice.finish_reason,
+        }
+        for key, value in (("response_id", getattr(response, "id", None)), ("model", getattr(response, "model", None)), ("request_id", getattr(response, "_request_id", None))):
+            if value is not None:
+                metadata[key] = value
+        prompt_details = getattr(usage, "prompt_tokens_details", None)
+        completion_details = getattr(usage, "completion_tokens_details", None)
+        cached_tokens = getattr(prompt_details, "cached_tokens", None)
+        reasoning_tokens = getattr(completion_details, "reasoning_tokens", None)
+        if cached_tokens is not None:
+            metadata["cached_tokens"] = cached_tokens
+        if reasoning_tokens is not None:
+            metadata["reasoning_tokens"] = reasoning_tokens
+        return response_message, metadata
+
+    def close(self) -> None:
+        self.openai_client.close()

--- a/tests/integration/run_orcarouter.py
+++ b/tests/integration/run_orcarouter.py
@@ -1,0 +1,9 @@
+from _shared import run_lifecycle
+
+
+if __name__ == "__main__":
+    run_lifecycle(
+        save_dir="outputs/orcarouter_test",
+        llm_model_name="orcarouter/anthropic/claude-opus-4.8",
+        embedding_model_name="text-embedding-3-small",
+    )

--- a/tests/test_orcarouter_llm.py
+++ b/tests/test_orcarouter_llm.py
@@ -1,0 +1,70 @@
+import os
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from hipporag.llm import _get_llm_class
+from hipporag.llm.orcarouter_llm import OrcaRouterLLM
+from hipporag.utils.config_utils import BaseConfig
+
+
+class OrcaRouterLLMTest(unittest.TestCase):
+    def make_config(self, save_dir):
+        return BaseConfig(
+            llm_name="orcarouter/anthropic/claude-opus-4.8",
+            save_dir=save_dir,
+        )
+
+    def test_provider_selection(self):
+        with tempfile.TemporaryDirectory() as save_dir, patch.dict(os.environ, {"ORCAROUTER_API_KEY": "sk-orca-test"}):
+            with patch("hipporag.llm.orcarouter_llm.OpenAI"):
+                self.assertIsInstance(_get_llm_class(self.make_config(save_dir)), OrcaRouterLLM)
+
+    def test_chat_completions_inference(self):
+        response = SimpleNamespace(
+            id="chatcmpl-orca-test",
+            model="orcarouter/anthropic/claude-opus-4.8",
+            choices=[SimpleNamespace(message=SimpleNamespace(content="HippoRAG OrcaRouter test passed"), finish_reason="stop")],
+            usage=SimpleNamespace(prompt_tokens=4, completion_tokens=5, total_tokens=9),
+        )
+        with tempfile.TemporaryDirectory() as save_dir, patch.dict(os.environ, {"ORCAROUTER_API_KEY": "sk-orca-test"}):
+            with patch("hipporag.llm.orcarouter_llm.OpenAI") as openai:
+                openai.return_value.chat.completions.create = MagicMock(return_value=response)
+                llm = OrcaRouterLLM(self.make_config(save_dir))
+                message, metadata, cached = llm.infer([{"role": "user", "content": "Test"}])
+
+        self.assertEqual(message, "HippoRAG OrcaRouter test passed")
+        self.assertEqual(metadata["prompt_tokens"], 4)
+        self.assertEqual(metadata["total_tokens"], 9)
+        self.assertFalse(cached)
+        openai.return_value.chat.completions.create.assert_called_once_with(
+            model="anthropic/claude-opus-4.8",
+            max_completion_tokens=2048,
+            temperature=0,
+            messages=[{"role": "user", "content": "Test"}],
+        )
+
+    def test_missing_api_key_is_an_error(self):
+        with tempfile.TemporaryDirectory() as save_dir, patch.dict(os.environ, {}, clear=True):
+            with self.assertRaisesRegex(ValueError, "ORCAROUTER_API_KEY"):
+                OrcaRouterLLM(self.make_config(save_dir))
+
+    def test_bare_prefix_is_rejected(self):
+        with tempfile.TemporaryDirectory() as save_dir, patch.dict(os.environ, {"ORCAROUTER_API_KEY": "sk-orca-test"}):
+            config = self.make_config(save_dir)
+            config.llm_name = "orcarouter/"
+            with self.assertRaisesRegex(ValueError, "vendor/model"):
+                OrcaRouterLLM(config)
+
+    def test_default_base_url_is_used_when_unset(self):
+        with tempfile.TemporaryDirectory() as save_dir, patch.dict(os.environ, {"ORCAROUTER_API_KEY": "sk-orca-test"}):
+            with patch("hipporag.llm.orcarouter_llm.OpenAI") as openai:
+                llm = OrcaRouterLLM(self.make_config(save_dir))
+
+        self.assertEqual(llm.llm_base_url, "https://api.orcarouter.ai/v1")
+        self.assertEqual(openai.call_args.kwargs["base_url"], "https://api.orcarouter.ai/v1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

HippoRAG is a memory framework for LLMs that recognizes and uses connections in new knowledge, mirroring a key function of human long-term memory. It already supports several named providers for its LLM calls — OpenAI via `llm_base_url`, Amazon Bedrock via the `bedrock/` prefix, and Amazon Bedrock Mantle via the `bedrock-mantle/` prefix. This PR adds **OrcaRouter** as another first-class, named provider, mirroring the existing OpenAI-compatible wiring so that HippoRAG users can reach OrcaRouter's gateway directly instead of treating it as an anonymous custom base URL.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## How it mirrors the existing provider wiring

The new provider is a direct parallel of the existing **Amazon Bedrock Mantle** wiring, which is the closest existing pattern for an OpenAI-compatible named provider:

| Piece | Existing (Bedrock Mantle) | New (OrcaRouter) |
| --- | --- | --- |
| Provider class | `src/hipporag/llm/bedrock_mantle.py` → `BedrockMantleLLM` | `src/hipporag/llm/orcarouter_llm.py` → `OrcaRouterLLM` |
| Dispatch prefix | `llm_name.startswith('bedrock-mantle/')` in `_get_llm_class` | `llm_name.startswith('orcarouter/')` in `_get_llm_class` |
| Model namespace | `bedrock-mantle/<model-id>` | `orcarouter/<vendor>/<model>` (e.g. `orcarouter/anthropic/claude-opus-4.8`) |
| Auth | `AWS_BEARER_TOKEN_BEDROCK` env var, required | `ORCAROUTER_API_KEY` env var, required |
| Default endpoint | explicit `llm_base_url` required | defaults to `https://api.orcarouter.ai/v1`, overridable via `llm_base_url` |
| Response caching | `@cache_response` + per-provider cache file | `@cache_response` + per-provider cache file |
| OpenIE provenance | dedicated branch in `_current_openie_provenance` | dedicated branch in `_current_openie_provenance` |
| Example | `examples/demo_bedrock_mantle.py` | `examples/demo_orcarouter.py` |
| Integration script | `tests/integration/run_azure.py` | `tests/integration/run_orcarouter.py` |

Like `BedrockMantleLLM`, the new `OrcaRouterLLM` builds an `OpenAI` client against the OpenAI Chat Completions API, validates the base URL with the shared `validate_openai_base_url` helper, fails closed when `ORCAROUTER_API_KEY` is missing, and reuses the shared `cache_response` decorator so identical prompts are served from the same SQLite cache that other providers use.

## Changes

- `src/hipporag/llm/orcarouter_llm.py` — new `OrcaRouterLLM` provider class.
- `src/hipporag/llm/__init__.py` — dispatch `orcarouter/` prefixed model names to `OrcaRouterLLM`.
- `src/hipporag/HippoRAG.py` — record the OrcaRouter endpoint in OpenIE provenance so persisted state stays consistent across the provider.
- `tests/test_orcarouter_llm.py` — unit tests mirroring `test_bedrock_mantle.py` (provider selection, inference, missing-key error, prefix validation, default base URL).
- `tests/integration/run_orcarouter.py` — integration script exercising index → QA → reload → incremental update → delete.
- `examples/demo_orcarouter.py` — minimal provider-specific usage example.
- `README.md` — document the OrcaRouter provider under Quick Start and list the integration script in the Testing table.

## Verification

- `python -m unittest discover -s tests -p 'test_*.py'` — 71 tests pass (66 existing + 5 new), no regressions.
- Live test against the real OrcaRouter endpoint (`ORCAROUTER_API_KEY`): `OrcaRouterLLM.infer` returned a 200 response through the full HippoRAG OpenIE path (NER + triple extraction completed successfully), and `examples/demo_orcarouter.py` printed the expected answer with usage metadata.

Contact: Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
